### PR TITLE
Upgrade Janeus

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,6 @@ PyMySQL==0.6.3
 python-dateutil
 icalendar==3.8.4
 -e git+https://github.com/jonge-democraten/mezzanine-fullcalendar@v0.6.5#egg=fullcalendar
--e git+https://github.com/jonge-democraten/python-ldap@py3#egg=python-ldap
--e git+https://github.com/jonge-democraten/janeus@1.2-mezzanine#egg=janeus
+-e git+https://github.com/jonge-democraten/janeus@1.4#egg=janeus
 -e git+https://github.com/jonge-democraten/hemres@0.6#egg=hemres
 inlinestyler==0.2.0

--- a/website/core/tests.py
+++ b/website/core/tests.py
@@ -336,4 +336,4 @@ class TestJaneus(TestCase):
         from janeus.backend import JaneusBackend
         user = JaneusBackend().authenticate("someuser", "somepass")
         self.assertTrue(user is not None)
-        self.assertTrue(user.user_permissions.count() == Permission.objects.count())
+        self.assertTrue(len(user.get_all_permissions()) == Permission.objects.count())


### PR DESCRIPTION
I did some testing of the new Janeus version on the new website.

It appears to work very well. The new version automatically detects the presence of mezzanine and uses the site ID for mezzanine in the login backend. It also creates mezzanine site permissions for all sites that a user has any active Janeus roles in.

One major difference is that this version no longer adds groups and permissions to the User object, but instead handles permissions directly in its own backend. This allows better control as to which site a user has which permissions for, effectively allowing a user with multiple roles to have different permissions per site.

I also removed python-ldap dependency from this requirements.txt file. Instead, Janeus has a setup.py that specifies the version of python-ldap to use, which currently is the pyldap library which officially supersedes python-ldap for python 3.0. Indeed that is the new repository that fork of python-ldap was pulled into.

In case you want to do a code review of Janeus 1.4, please study https://github.com/jonge-democraten/janeus/blob/master/janeus/backend.py. The commits themselves are quite large, so just look at the end result.