### PR TITLE
Rewrite blog category page

### DIFF
--- a/website/templates/pages/blogcategorypage.html
+++ b/website/templates/pages/blogcategorypage.html
@@ -1,23 +1,41 @@
-<?php require('components/component-site-start.php'); ?>
-<?php require('components/component-nav.php'); ?>
-<?php require('components/component-header-default.php'); ?>
-<?php require('components/component-site-wrapper-start.php'); ?>
+{% extends "base.html" %}
+
+{% load i18n mezzanine_tags %}
+
+{% block meta_title %}
+  {% block meta_title2 %}
+    {% if page %}
+      {{ page.meta_title }}
+    {% else %}
+      {% trans "Blog" %}
+    {% endif %}
+  {% endblock %}
+{% endblock %}
+
+{% block main %}
+
 <!-- start nieuws specific -->
 <section class="force-xlg-container col-lg-10 col-md-10 col-sm-10 col-xs-12 col-lg-offset-1 col-md-offset-1 col-sm-offset-1 col-xs-offset-0">
-	<div class="news list-container">
-		<div class="list-content col-lg-8 col-md-8 col-sm-12 col-xs-12">
-			<?php foreach(Array(1,2) as $count): ?>
-				<?php require('components/content/nieuws/content-news-item.php'); ?>
-			<?php endforeach; ?>
-			<?php require('components/component-pagination.php'); ?>
-		</div>
-		<div class="col-lg-4 col-md-4 col-sm-12 col-xs-12">
-			<?php require('components/sidebar/sidebar-categories.php'); ?>
-			<?php require('components/sidebar/sidebar-twitter.php'); ?>
-		</div>
-	</div>
+  <div class="news list-container">
+    <div class="list-content col-lg-8 col-md-8 col-sm-12 col-xs-12">
+      {% for blog_post in blog_posts.object_list %}
+        <article class="list-item">
+          <h2>{{ blog_post.title }}</h2>
+          <h3><i class="gd gd-clock"></i>{{ blog_post.publish_date|date:"d M Y" }}</h3>
+          {{ blog_post.description_from_content|richtext_filters|safe }}
+          <a class="button" href="{{ blog_post.get_absolute_url }}">{% trans "Lees verder" %}</a>
+        </article>
+      {% endfor %}
+      <div class="pagination">
+        <h3>{% pagination_for blog_posts %}</h3>
+      </div>
+    </div>
+    <div class="col-lg-4 col-md-4 col-sm-12 col-xs-12">
+      <?php require('components/sidebar/sidebar-categories.php'); ?>
+      <?php require('components/sidebar/sidebar-twitter.php'); ?>
+    </div>
+  </div>
 </section>
-<!-- end nieuws specific -->
-<?php require('components/component-site-wrapper-end.php'); ?>
-<?php require('components/component-footer.php'); ?>
-<?php require('components/component-site-end.php'); ?>
+
+{% endblock %}
+


### PR DESCRIPTION
De pagina `templates/pages/blogcategorypage.html` is herschreven volgens de filosofie van Django.

Vragen / opmerkingen:

- Er was wat gedoe met line endings. In de diff stond aan het einde van elke door mij toegevoegde regel de markering `^M`. Dit zou opgelost moeten worden door `git config --global core.autocrlf true` (op Windows) of `git config --global core.autocrlf input` (op Linux), maar ik had het idee dat deze commando's allebei niks deden. Ik heb verschillende dingen geprobeerd: reset en add, commit en reset, e.d. Uiteindelijk heb ik maar gewoon gecommit.
- De file bevatte veel php requires. Zijn dit (tijdelijke) placeholders, en mogen ze dus weg? Of zijn ze nog nodig? Ik heb nu alle placeholders weggehaald, behalve die van twitter en facebook.
- De nieuwe versie van de blog category page lijkt helemaal goed. Alleen de eerste regel van elke post wordt getoond. Doorklikken op de details toont het hele bericht. Ook paginating werkt. De stijl van de paginating knoppen moet wellicht nog in een ander issue gefixt worden.

Laat maar weten of je nog dingen tegenkomt, of dat ik bepaalde denkfouten heb gemaakt.