### PR TITLE
Improve header image responsiveness and filesize

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,5 +70,5 @@ target/
 local_settings.py
 
 # folder containing test images
-website/static/website/media/uploads/gallery/
+website/static/website/media/
 

--- a/website/jdpages/models.py
+++ b/website/jdpages/models.py
@@ -70,8 +70,10 @@ def validate_header_image(imagepath):
     aspect_ratio = width/height
     if aspect_ratio < 2.0:
         raise ValidationError('Image aspect ratio should be at least 2 (for example 2000x1000px). The selected image is %i x %i. Please resize the image.' % (width, height))
-    if width < 1000:
-        raise ValidationError('Image resolution is too low. It should be at least 1000px wide. The selected image is %i x %i. Please find a larger image.' % (width, height))
+    if width < 1500:
+        raise ValidationError('Image resolution is too low. Width should at least be 1500px. The selected image is %i x %i. Please find a larger image.' % (width, height))
+    if height < 250:
+        raise ValidationError('Image resolution is too low. Height should at least be 250px. The selected image is %i x %i. Please find a larger image.' % (width, height))
 
 
 class PageHeaderImage(SiteRelated):

--- a/website/templates/components/header_default.html
+++ b/website/templates/components/header_default.html
@@ -1,11 +1,12 @@
 {% load static %}
+{% load mezzanine_tags %}
 
 <header class="small-view">
     <figure>
         {% if page_header.image %}
-            <img src="{{ page_header.image.url }}" alt="#"/>
+            <img src="{{ MEDIA_URL }}{% thumbnail page_header.image 2500 0 upscale=True quality=75 %}" alt="#"/>
         {% else %}
-            <img src="{{ homepage_header.image.url }}" alt="#"/>
+            <img src="{{ MEDIA_URL }}{% thumbnail homepage_header.image 2500 0 upscale=True quality=75 %}" alt="#"/>
         {% endif %}
         <figcaption class="force-xlg-container col-lg-10 col-md-10 col-sm-10 col-xs-12 col-lg-offset-1 col-md-offset-1 col-sm-offset-1 col-xs-offset-0">
             <h2>{{ page.title }}</h2>

--- a/website/templates/components/header_home.html
+++ b/website/templates/components/header_home.html
@@ -1,8 +1,9 @@
 {% load static %}
+{% load mezzanine_tags %}
 
 <header class="large-view">
     <figure>
-        <img src="{{ page_header.image.url }}" alt="#"/>
+        <img src="{{ MEDIA_URL }}{% thumbnail page_header.image 2500 0 upscale=True quality=75 %}" alt="#"/>
         <figcaption class="force-xlg-container col-lg-10 col-md-10 col-sm-10 col-xs-12 col-lg-offset-1 col-md-offset-1 col-sm-offset-1 col-xs-offset-0">
             <h2>{{ page.homepage.header_title }}</h2>
             <h3>{{ page.homepage.header_subtitle }}</h3>


### PR DESCRIPTION
Use the mezzanine `thumbnail` tag to resize header images to a width of 2500 pixels and a jpeg quality of 75.

Images are automatically resized, but only if the size does not yet exist.

This fixes gray areas on the right and left of the header on large/high-res screens by upscaling images. 
And fixes possible large image file sizes.

Typical header image size will now be 100-300 kB.

Downside is a possible quality loss due to upscaling, but this is only really visible on wide screens and better than a gray area, in my opinion. 
Moreover, images that were already highly compressed will now become a bit bigger. I think this is acceptable. 